### PR TITLE
refactor: add ability to enable/disable frida server on boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,17 @@ A simple yet powerful Magisk module that automates starting the [Frida](https://
 Use the `mafrida` CLI tool to manage the [Frida](https://github.com/frida/frida) server:
 
 ```sh
-Usage: mafrida [--set <frida-version> | -g | download | kill | start | status]
-
-  --set <version>   Set and install the specified Frida version (e.g., 16.1.4)
-  -g                Show the currently set Frida version
-  download          Download the frida-server binary for the set version
-  kill              Force kill any running frida-server instance
-  start             Start frida-server using the set version
-  status            Check if frida-server is currently running
+function script_usage() {
+    printf "Usage: mafrida [--set <frida-version> | -g | kill | start | status]\n"
+    printf "  --set <version>   Set and install the specified Frida version (e.g., 16.1.4)\n"
+    printf "  -g                Show the currently set Frida version\n"
+    printf "  download          Download the frida-server binary for the set version\n"
+    printf "  kill              Force kill any running frida-server instance\n"
+    printf "  start             Start frida-server using the set version\n"
+    printf "  status            Check if frida-server is currently running\n"
+    printf "  enable            Enable frida-server to auto-start on boot\n"
+    printf "  disable           Disable frida-server from auto-starting on boot\n"
+}
 ```
 
 ### Examples
@@ -52,15 +55,25 @@ mafrida start
 
 #### Check server status:
 
-```
+```sh
 mafrida status
 ```
 
 #### Kill the running instance:
 
-```
+```sh
 mafrida kill
 ````
+
+#### Enable frida server on boot
+```sh
+mafrida enable
+```
+
+#### Disable frida server on boot
+```sh
+mafrida disable
+```
 
 ## Requirements
 

--- a/scripts/mafrida
+++ b/scripts/mafrida
@@ -12,6 +12,8 @@ function script_usage() {
     printf "  kill              Force kill any running frida-server instance\n"
     printf "  start             Start frida-server using the set version\n"
     printf "  status            Check if frida-server is currently running\n"
+    printf "  enable            Enable frida-server to auto-start on boot\n"
+    printf "  disable           Disable frida-server from auto-starting on boot\n"
 }
 
 
@@ -80,8 +82,27 @@ if [[ $# -lt 3 ]]; then
         else
             echo "- server is not running :("
         fi;
-
     
+    # enable frida server to start on boot
+    elif [[ $1 == "enable" ]]; then
+        if [[ -f "$VERSION_DIR/.onboot_disabled" ]]; then
+            rm -f "$VERSION_DIR/.onboot_disabled"
+            echo "- Frida server enabled on boot."
+        else
+            echo "- Frida server is already enabled on boot."
+            exit 1;
+        fi;
+
+    # disable frida server on boot    
+    elif [[ $1 == "disable" ]]; then
+        if [[ -f "$VERSION_DIR/.onboot_disabled" ]]; then
+            echo "- Frida server is already disabled on boot."
+            exit 1;
+        else
+            >"$VERSION_DIR/.onboot_disabled"
+            echo "- Frida server disabled on boot"
+        fi;
+
     else
         script_usage
 

--- a/service.sh
+++ b/service.sh
@@ -13,5 +13,10 @@ set -x
 sleep 20 # sleep for 20 second, to warm up the device
 init_download_dir
 init_frida_server
-run_frida
 
+if [[ -f "$MODPATH/.onboot_disabled" ]]; then
+    echo "- Frida server auto-start is disabled!"
+    exit 1;
+else
+    run_frida
+fi;


### PR DESCRIPTION
You can now enable or disable the Frida server on boot, as suggested in #16 

You can use the:

```sh
mafrida enable
```
to enable frida server on boot, and

```sh
mafrida disable
```

to disable it.